### PR TITLE
Redeploy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,9 @@ Authors@R: c(
     person("Ozayr", "Mohammed", , "ozayr.mohammed@nhs.net", role = "aut"),
     person("Rhian", "Davies", , "rhian.davies25@nhs.net", role = "ctb")
   )
-Description: A Shiny app for exploring renal evidence.
+Description: An app to allow exploration of the evidence map for Renal
+    Service Modelling. Built in conjunction with the Evidence and
+    Knowledge Team.
 License: MIT + file LICENSE
 Depends: 
     R (>= 2.10)

--- a/R/fct_data.R
+++ b/R/fct_data.R
@@ -1,6 +1,6 @@
 get_pinned_data <- function(pin_name) {
 
-  board <- pins::board_connect()
+  board <- pins::board_connect(server = "connect.strategyunitwm.nhs.uk")
   pin_exists <- pins::pin_exists(board, pin_name)
 
   if (!pin_exists) stop(glue::glue("The pin {pin_name} could not be found"))

--- a/R/fct_data.R
+++ b/R/fct_data.R
@@ -1,6 +1,9 @@
-get_pinned_data <- function(pin_name) {
+get_pinned_data <- function(
+    pin_name,
+    server_name = "https://connect.strategyunitwm.nhs.uk/"
+) {
 
-  board <- pins::board_connect(server = "connect.strategyunitwm.nhs.uk")
+  board <- pins::board_connect(server = server_name)
   pin_exists <- pins::pin_exists(board, pin_name)
 
   if (!pin_exists) stop(glue::glue("The pin {pin_name} could not be found"))

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -1,56 +1,18 @@
-# Building a Prod-Ready, Robust Shiny Application.
-#
-# README: each step of the dev files is optional, and you don't have to
-# fill every dev scripts before getting started.
-# 01_start.R should be filled at start.
-# 02_dev.R should be used to keep track of your development during the project.
-# 03_deploy.R should be used once you need to deploy your app.
-#
-#
-######################################
-#### CURRENT FILE: DEPLOY SCRIPT #####
-######################################
+deploy <- function(server_name, app_id) {
+  rsconnect::deployApp(
+    server = server_name,
+    appFiles = c(
+      "R/",
+      "inst/",
+      "NAMESPACE",
+      "DESCRIPTION",
+      "app.R"
+    ),
+    appId = app_id,
+    lint = FALSE,
+    forceUpdate = TRUE
+  )
+}
 
-# Test your app
-
-## Run checks ----
-## Check the package before sending to prod
-devtools::check()
-rhub::check_for_cran()
-
-# Deploy
-
-## Local, CRAN or Package Manager ----
-## This will build a tar.gz that can be installed locally,
-## sent to CRAN, or to a package manager
-# devtools::build()
-
-## RStudio ----
-## If you want to deploy on RStudio related platforms
-# golem::add_rstudioconnect_file()
-# golem::add_shinyappsio_file()
-# golem::add_shinyserver_file()
-
-## Docker ----
-## If you want to deploy via a generic Dockerfile
-# golem::add_dockerfile_with_renv()
-
-## If you want to deploy to ShinyProxy
-# golem::add_dockerfile_with_renv_shinyproxy()
-
-
-# Deploy to Posit Connect or ShinyApps.io
-# In command line.
-rsconnect::deployApp(
-  appFiles = c(
-    # Add any additional files unique to your app here.
-    "R/",
-    "inst/",
-    "NAMESPACE",
-    "DESCRIPTION",
-    "app.R"
-  ),
-  appId = rsconnect::deployments(".")$appID,
-  lint = FALSE,
-  forceUpdate = TRUE
-)
+deploy("connect.strategyunitwm.nhs.uk", 306)
+deploy("connect.su.mlcsu.org", 92)


### PR DESCRIPTION
Close #33.

* Add double-deploy script.
* Name the server where the pin lives.
* Update DESCRIPTION.

Have already redeployed to old server and to new server using the `deploy.R` script. Note that the app fails on the new server because it needs auth to access the pin. When the pin is deployed on the new server, and the new server takes the old server name, then auth won't be required anymore and the app will work as intended.